### PR TITLE
Switch USER at the end to not run as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,4 @@ RUN adduser --disabled-password \
     --uid ${NB_UID} \
     ${NB_USER}
 WORKDIR ${HOME}
+USER ${USER}


### PR DESCRIPTION
When I run this repo with `repo2docker https://github.com/binder-examples/minimal-dockerfile` I end up with a warning that says "running as root isn't recommended". Switching users at the end fixes that. Is there a reason not to switch?

cc @minrk